### PR TITLE
Add missing starting backslash to endpoint types

### DIFF
--- a/src/OpencastApi/Opencast.php
+++ b/src/OpencastApi/Opencast.php
@@ -6,67 +6,67 @@ use OpencastApi\Rest\OcIngest;
 
 class Opencast
 {
-    /** @var OpencastApi\Rest\OcRestClient the rest client */
+    /** @var OcRestClient the rest client */
     private $restClient;
 
-    /** @var OpencastApi\Rest\OcRestClient the engage node rest client */
+    /** @var OcRestClient the engage node rest client */
     private $engageRestClient;
 
-    // Avoid PHP 8.2 deprecates the creation of dynamic class properties.
+    // PHP 8.2 deprecates the creation of dynamic class properties.
     // We also need to avoid the type declaration to provide the possibility of using Decorate proxy.
 
-    /** @var OpencastApi\Rest\OcAgentsApi $agentsApi */
+    /** @var \OpencastApi\Rest\OcAgentsApi $agentsApi */
     public $agentsApi;
 
-    /** @var OpencastApi\Rest\OcBaseApi $baseApi */
+    /** @var \OpencastApi\Rest\OcBaseApi $baseApi */
     public $baseApi;
 
-    /** @var OpencastApi\Rest\OcCaptureAdmin $captureAdmin */
+    /** @var \OpencastApi\Rest\OcCaptureAdmin $captureAdmin */
     public $captureAdmin;
 
-    /** @var OpencastApi\Rest\OcEventAdminNg $eventAdminNg */
+    /** @var \OpencastApi\Rest\OcEventAdminNg $eventAdminNg */
     public $eventAdminNg;
 
-    /** @var OpencastApi\Rest\OcEventsApi $eventsApi */
+    /** @var \OpencastApi\Rest\OcEventsApi $eventsApi */
     public $eventsApi;
 
-    /** @var OpencastApi\Rest\OcGroupsApi $groupsApi */
+    /** @var \OpencastApi\Rest\OcGroupsApi $groupsApi */
     public $groupsApi;
 
-    /** @var OpencastApi\Rest\OcRecordings $recordings */
+    /** @var \OpencastApi\Rest\OcRecordings $recordings */
     public $recordings;
 
-    /** @var OpencastApi\Rest\OcSearch $search */
+    /** @var \OpencastApi\Rest\OcSearch $search */
     public $search;
 
-    /** @var OpencastApi\Rest\OcSecurityApi $securityApi */
+    /** @var \OpencastApi\Rest\OcSecurityApi $securityApi */
     public $securityApi;
 
-    /** @var OpencastApi\Rest\OcSeriesApi $seriesApi */
+    /** @var \OpencastApi\Rest\OcSeriesApi $seriesApi */
     public $seriesApi;
 
-    /** @var OpencastApi\Rest\OcSeries $series */
+    /** @var \OpencastApi\Rest\OcSeries $series */
     public $series;
 
-    /** @var OpencastApi\Rest\OcServices $services */
+    /** @var \OpencastApi\Rest\OcServices $services */
     public $services;
 
-    /** @var OpencastApi\Rest\OcStatisticsApi $statisticsApi */
+    /** @var \OpencastApi\Rest\OcStatisticsApi $statisticsApi */
     public $statisticsApi;
 
-    /** @var OpencastApi\Rest\OcSysinfo $sysinfo */
+    /** @var \OpencastApi\Rest\OcSysinfo $sysinfo */
     public $sysinfo;
 
-    /** @var OpencastApi\Rest\OcWorkflow $agentsApi */
+    /** @var \OpencastApi\Rest\OcWorkflow $agentsApi */
     public $workflow;
 
-    /** @var OpencastApi\Rest\OcWorkflowsApi $workflowsApi */
+    /** @var \OpencastApi\Rest\OcWorkflowsApi $workflowsApi */
     public $workflowsApi;
 
-    /** @var OpencastApi\Rest\OcIngest $ingest */
+    /** @var \OpencastApi\Rest\OcIngest $ingest */
     public $ingest;
 
-    /** @var OpencastApi\Rest\OcListProvidersApi $listProvidersApi */
+    /** @var \OpencastApi\Rest\OcListProvidersApi $listProvidersApi */
     public $listProvidersApi;
 
     /*


### PR DESCRIPTION
The types are missing a starting backslash. No functional changes, but this will enable autocompletion for api endpoint methods :)