### PR TITLE
Reflect changes in the search service for OC 16.

### DIFF
--- a/src/OpencastApi/Opencast.php
+++ b/src/OpencastApi/Opencast.php
@@ -81,6 +81,7 @@ class Opencast
             'connect_timeout' => 0                          // The API connection timeout. In seconds (default 0 to wait indefinitely) (optional)
             'version' => null                               // The API Version. (Default null). (optional)
             'handler' => null                               // The callable Handler or HandlerStack. (Default null). (optional)
+            'features' => null                              // A set of additional features [e.g. lucene search]. (Default null). (optional)
         ]
 
         $engageConfig = [
@@ -91,6 +92,7 @@ class Opencast
             'connect_timeout' => 0                          // The API connection timeout. In seconds (default 0 to wait indefinitely) (optional)
             'version' => null                               // The API Version. (Default null). (optional)
             'handler' => null                               // The callable Handler or HandlerStack. (Default null). (optional)
+            'features' => null                              // A set of additional features [e.g. lucene search]. (Default null). (optional)
         ]
     */
     /**
@@ -133,13 +135,6 @@ class Opencast
             // NOTE: services must be instantiated before calling setIngest method!
             $this->setIngestProperty($config);
         }
-
-        // allow to disable lucene search present only up to oc 15, default is enabled
-        if (isset($config['features']['lucene'])
-            && $config['features']['lucene'] == false
-        ) {
-            $this->search->lucene = false;
-        }
     }
 
     private function excludeFilters()
@@ -177,6 +172,9 @@ class Opencast
         }
         if (!isset($engageConfig['handler']) && isset($config['handler'])) {
             $engageConfig['handler'] = $config['handler'];
+        }
+        if (!isset($engageConfig['features']) && isset($config['features'])) {
+            $engageConfig['features'] = $config['features'];
         }
         $this->engageRestClient = new OcRestClient($engageConfig);
     }

--- a/src/OpencastApi/Opencast.php
+++ b/src/OpencastApi/Opencast.php
@@ -133,6 +133,13 @@ class Opencast
             // NOTE: services must be instantiated before calling setIngest method!
             $this->setIngestProperty($config);
         }
+
+        // allow to disable lucene search present only up to oc 15, default is enabled
+        if (isset($config['features']['lucene'])
+            && $config['features']['lucene'] == false
+        ) {
+            $this->search->lucene = false;
+        }
     }
 
     private function excludeFilters()

--- a/src/OpencastApi/Rest/OcRestClient.php
+++ b/src/OpencastApi/Rest/OcRestClient.php
@@ -17,6 +17,7 @@ class OcRestClient extends Client
     private $additionalHeaders = [];
     private $noHeader = false;
     private $origin;
+    private $features = [];
     /*
         $config = [
             'url' => 'https://develop.opencast.org/',       // The API url of the opencast instance (required)
@@ -24,8 +25,9 @@ class OcRestClient extends Client
             'password' => 'opencast',                       // The API password. (required)
             'timeout' => 0,                                 // The API timeout. In seconds (default 0 to wait indefinitely). (optional)
             'connect_timeout' => 0,                         // The API connection timeout. In seconds (default 0 to wait indefinitely) (optional)
-            'version' => null                               // The API Version. (Default null). (optional)
-            'handler' => null                               // The callable Handler or HandlerStack. (Default null). (optional)
+            'version' => null,                               // The API Version. (Default null). (optional)
+            'handler' => null,                               // The callable Handler or HandlerStack. (Default null). (optional)
+            'features' => null                              // A set of additional features [e.g. lucene search]. (Default null). (optional)
         ]
     */
     public function __construct($config)
@@ -51,7 +53,23 @@ class OcRestClient extends Client
         if (isset($config['handler']) && is_callable($config['handler'])) {
             $parentConstructorConfig['handler'] = $config['handler'];
         }
+
+        if (isset($config['features'])) {
+            $this->features = $config['features'];
+        }
+
         parent::__construct($parentConstructorConfig);
+    }
+
+    public function readFeatures($key = null) {
+        if (empty($key)) {
+            return $this->features;
+        }
+
+        if (isset($this->features[$key])) {
+            return $this->features[$key];
+        }
+        return false;
     }
 
     public function registerHeaderException($header, $path) {

--- a/src/OpencastApi/Rest/OcSearch.php
+++ b/src/OpencastApi/Rest/OcSearch.php
@@ -1,9 +1,10 @@
-<?php 
+<?php
 namespace OpencastApi\Rest;
 
 class OcSearch extends OcRest
 {
     const URI = '/search';
+    public $lucene = true;
 
     public function __construct($restClient)
     {
@@ -11,11 +12,11 @@ class OcSearch extends OcRest
         parent::__construct($restClient);
     }
 
-    
+
     /**
      * Search for episodes matching the query parameters as object (JSON) by default or XML (text) on demand.
-     * 
-     * @param array $params the params to pass to the call: it must cointain the following: 
+     *
+     * @param array $params the params to pass to the call: it must cointain the following:
      * $params = [
      *      'id' => '{The ID of the single episode to be returned, if it exists}',
      *      'q' => '{Any episode that matches this free-text query.}',
@@ -28,7 +29,7 @@ class OcSearch extends OcRest
      *      'sign' => '{If results are to be signed (Default value=true)}',
      * ]
      * @param string $format The output format (json or xml) of the response body. (Default value = 'json')
-     * 
+     *
      * @return array the response result ['code' => 200, 'body' => '{The search results, formatted as xml or json}']
      */
     public function getEpisodes($params = [], $format = '')
@@ -64,30 +65,56 @@ class OcSearch extends OcRest
             $query['sign'] = $params['sign'];
         }
 
-        $sortsASC = [
-            'DATE_CREATED', 'DATE_MODIFIED', 'TITLE', 'SERIES_ID',
-            'MEDIA_PACKAGE_ID', 'CREATOR', 'CONTRIBUTOR', 'LANGUAGE',
-            'LICENSE','SUBJECT','DESCRIPTION','PUBLISHER',
-        ];
-        $sortsDESC = array_map(function ($sort) {
-            return "{$sort}_DESC";
-        }, $sortsASC);
 
-        $sorts = array_merge($sortsASC, $sortsDESC);
-        
-        if (array_key_exists('sort', $params) && !empty($params['sort']) &&
-            in_array($params['sort'], $sorts)) {
-            $query['sort'] = $params['sort'];
+        // OC <= 15
+        if ($this->lucene) {
+            $sortsASC = [
+                'DATE_CREATED', 'DATE_MODIFIED', 'TITLE', 'SERIES_ID',
+                'MEDIA_PACKAGE_ID', 'CREATOR', 'CONTRIBUTOR', 'LANGUAGE',
+                'LICENSE','SUBJECT','DESCRIPTION','PUBLISHER',
+            ];
+            $sortsDESC = array_map(function ($sort) {
+                return "{$sort}_DESC";
+            }, $sortsASC);
+
+            $sorts = array_merge($sortsASC, $sortsDESC);
+
+            if (array_key_exists('sort', $params) && !empty($params['sort']) &&
+                in_array($params['sort'], $sorts)) {
+                $query['sort'] = $params['sort'];
+            }
+
+        // OC >= 16
+        } else {
+            $sorts = [
+                'modified', 'title', 'creator', 'contributor'
+            ];
+
+            $sortsASC = array_map(function ($sort) {
+                return "{$sort} asc";
+            }, $sorts);
+
+            $sortsDESC = array_map(function ($sort) {
+                return "{$sort} desc";
+            }, $sorts);
+
+            $sorts_list = array_merge($sorts, $sortsASC, $sortsDESC);
+
+            if (array_key_exists('sort', $params) && !empty($params['sort']) &&
+                in_array(strtolower($params['sort']), $sorts_list)) {
+                $query['sort'] = strtolower($params['sort']);
+            }
         }
-        
+
         $options = $this->restClient->getQueryParams($query);
         return $this->restClient->performGet($uri, $options);
     }
 
+
     /**
      * Search a lucene query as object (JSON) by default or XML (text) on demand.
-     * 
-     * @param array $params the params to pass to the call: it must cointain the following: 
+     *
+     * @param array $params the params to pass to the call: it must cointain the following:
      * $params = [
      *      'q' => '{ The lucene query. }',
      *      'series' => '{ Include series in the search result. (Default value=false)}',
@@ -98,11 +125,15 @@ class OcSearch extends OcRest
      *      'sign' => '{If results are to be signed (Default value=true)}',
      * ]
      * @param string $format The output format (json or xml) of the response body. (Default value = 'json')
-     * 
+     *
      * @return array the response result ['code' => 200, 'body' => '{The search results, formatted as xml or json}']
      */
     public function getLucene($params = [], $format = '')
     {
+        if (!$this->lucene) {
+            return false;
+        }
+
         $uri = self::URI . "/lucene.json";
         if (!empty($format) && strtolower($format) == 'xml') {
             $uri = str_replace('json', 'xml', $uri);
@@ -138,20 +169,20 @@ class OcSearch extends OcRest
         }, $sortsASC);
 
         $sorts = array_merge($sortsASC, $sortsDESC);
-        
+
         if (array_key_exists('sort', $params) && !empty($params['sort']) &&
             in_array($params['sort'], $sorts)) {
             $query['sort'] = $params['sort'];
         }
-        
+
         $options = $this->restClient->getQueryParams($query);
         return $this->restClient->performGet($uri, $options);
     }
 
     /**
      * Search for series matching the query parameters and returns JSON (object) by default or XML (text) on demand
-     * 
-     * @param array $params the params to pass to the call: it must cointain the following: 
+     *
+     * @param array $params the params to pass to the call: it must cointain the following:
      * $params = [
      *      'id' = '{The series ID. If the additional boolean parameter "episodes" is "true", the result set will include this series episodes.}'
      *      'q' => '{Any series that matches this free-text query. If the additional boolean parameter "episodes" is "true", the result set will include this series episodes.}',
@@ -163,7 +194,7 @@ class OcSearch extends OcRest
      *      'sign' => '{If results are to be signed (Default value=true)}',
      * ]
      * @param string $format The output format (json or xml) of the response body. (Default value = 'json')
-     * 
+     *
      * @return array the response result ['code' => 200, 'body' => '{The search results, formatted as xml or json}']
      */
     public function getSeries($params = [], $format = '')
@@ -196,22 +227,46 @@ class OcSearch extends OcRest
             $query['sign'] = $params['sign'];
         }
 
-        $sortsASC = [
-            'DATE_CREATED', 'DATE_MODIFIED', 'TITLE', 'SERIES_ID',
-            'MEDIA_PACKAGE_ID', 'CREATOR', 'CONTRIBUTOR', 'LANGUAGE',
-            'LICENSE','SUBJECT','DESCRIPTION','PUBLISHER',
-        ];
-        $sortsDESC = array_map(function ($sort) {
-            return "{$sort}_DESC";
-        }, $sortsASC);
+        // OC <= 15
+        if ($this->lucene) {
+            $sortsASC = [
+                'DATE_CREATED', 'DATE_MODIFIED', 'TITLE', 'SERIES_ID',
+                'MEDIA_PACKAGE_ID', 'CREATOR', 'CONTRIBUTOR', 'LANGUAGE',
+                'LICENSE','SUBJECT','DESCRIPTION','PUBLISHER',
+            ];
+            $sortsDESC = array_map(function ($sort) {
+                return "{$sort}_DESC";
+            }, $sortsASC);
 
-        $sorts = array_merge($sortsASC, $sortsDESC);
-        
-        if (array_key_exists('sort', $params) && !empty($params['sort']) &&
-            in_array($params['sort'], $sorts)) {
-            $query['sort'] = $params['sort'];
+            $sorts = array_merge($sortsASC, $sortsDESC);
+
+            if (array_key_exists('sort', $params) && !empty($params['sort']) &&
+                in_array($params['sort'], $sorts)) {
+                $query['sort'] = $params['sort'];
+            }
+
+        // OC >= 16
+        } else {
+            $sorts = [
+                'modified', 'title', 'creator', 'contributor'
+            ];
+
+            $sortsASC = array_map(function ($sort) {
+                return "{$sort} asc";
+            }, $sorts);
+
+            $sortsDESC = array_map(function ($sort) {
+                return "{$sort} desc";
+            }, $sorts);
+
+            $sorts_list = array_merge($sorts, $sortsASC, $sortsDESC);
+
+            if (array_key_exists('sort', $params) && !empty($params['sort']) &&
+                in_array(strtolower($params['sort']), $sorts_list)) {
+                $query['sort'] = strtolower($params['sort']);
+            }
         }
-        
+
         $options = $this->restClient->getQueryParams($query);
         return $this->restClient->performGet($uri, $options);
     }

--- a/src/OpencastApi/Rest/OcSearch.php
+++ b/src/OpencastApi/Rest/OcSearch.php
@@ -4,12 +4,15 @@ namespace OpencastApi\Rest;
 class OcSearch extends OcRest
 {
     const URI = '/search';
-    public $lucene = true;
+    public $lucene = false; // By default false, main support for OC 16.
 
     public function __construct($restClient)
     {
         $restClient->registerHeaderException('Accept', self::URI);
         parent::__construct($restClient);
+        if ($restClient->readFeatures('lucene')) {
+            $this->lucene = true;
+        }
     }
 
 
@@ -114,6 +117,8 @@ class OcSearch extends OcRest
     /**
      * Search a lucene query as object (JSON) by default or XML (text) on demand.
      *
+     * INFO: This endpoint is removed in Opencast 16.
+     *
      * @param array $params the params to pass to the call: it must cointain the following:
      * $params = [
      *      'q' => '{ The lucene query. }',
@@ -131,7 +136,7 @@ class OcSearch extends OcRest
     public function getLucene($params = [], $format = '')
     {
         if (!$this->lucene) {
-            return false;
+            return ['code' => 410, 'reason' => 'Lucene search endpoint is not available!'];
         }
 
         $uri = self::URI . "/lucene.json";

--- a/tests/DataProvider/SearchDataProvider.php
+++ b/tests/DataProvider/SearchDataProvider.php
@@ -7,27 +7,10 @@ class SearchDataProvider {
     {
         return [
             [[], 'json'],
-            [[], 'xml'],
-            [[], 'XML'],
             [['id' => 'fe0b45b0-7ed5-4944-8b0a-a0a283331791'], ''],
             [['sid' => '8010876e-1dce-4d38-ab8d-24b956e3d8b7'], ''],
             [['sname' => 'HUB_LOCAL_TEST'], ''],
-            [['sort' => 'DATE_CREATED_DESC'], ''],
-            [['offset' => 1], ''],
-            [['limit' => 1], ''],
-            [['admin' => true], ''],
-            [['sign' => true], ''],
-        ];
-    }
-
-    public static function getLuceneQueryCases(): array
-    {
-        return [
-            [[], 'json'],
-            [[], 'xml'],
-            [[], 'XML'],
-            [['series' => true], ''],
-            [['sort' => 'DATE_CREATED_DESC'], ''],
+            [['sort' => 'modified asc'], ''],
             [['offset' => 1], ''],
             [['limit' => 1], ''],
             [['admin' => true], ''],
@@ -39,11 +22,9 @@ class SearchDataProvider {
     {
         return [
             [[], 'json'],
-            [[], 'xml'],
-            [[], 'XML'],
             [['id' => '8010876e-1dce-4d38-ab8d-24b956e3d8b7'], ''],
             [['episodes' => true], ''],
-            [['sort' => 'DATE_CREATED_DESC'], ''],
+            [['sort' => 'created desc'], ''],
             [['offset' => 1], ''],
             [['limit' => 1], ''],
             [['admin' => true], ''],

--- a/tests/DataProvider/SearchDataProvider.php
+++ b/tests/DataProvider/SearchDataProvider.php
@@ -1,8 +1,8 @@
-<?php 
+<?php
 namespace Tests\DataProvider;
 
 class SearchDataProvider {
-    
+
     public static function getEpisodeQueryCases(): array
     {
         return [
@@ -18,13 +18,28 @@ class SearchDataProvider {
         ];
     }
 
+    public static function getLuceneQueryCases(): array
+    {
+        return [
+            [[], 'json'],
+            [[], 'xml'],
+            [[], 'XML'],
+            [['series' => true], ''],
+            [['sort' => 'DATE_CREATED_DESC'], ''],
+            [['offset' => 1], ''],
+            [['limit' => 1], ''],
+            [['admin' => true], ''],
+            [['sign' => true], ''],
+        ];
+    }
+
     public static function getSeriesQueryCases(): array
     {
         return [
             [[], 'json'],
             [['id' => '8010876e-1dce-4d38-ab8d-24b956e3d8b7'], ''],
             [['episodes' => true], ''],
-            [['sort' => 'created desc'], ''],
+            [['sort' => 'modified desc'], ''],
             [['offset' => 1], ''],
             [['limit' => 1], ''],
             [['admin' => true], ''],

--- a/tests/DataProvider/SetupDataProvider.php
+++ b/tests/DataProvider/SetupDataProvider.php
@@ -15,7 +15,7 @@ class SetupDataProvider {
             'username' => $username,
             'password' => $password,
             'timeout' => $timeout,
-            'version' => '1.9.0',
+            'version' => '1.11.0',
             'connect_timeout' => $connectTimeout,
             'features' => [
                 'lucene' => false

--- a/tests/DataProvider/SetupDataProvider.php
+++ b/tests/DataProvider/SetupDataProvider.php
@@ -16,7 +16,10 @@ class SetupDataProvider {
             'password' => $password,
             'timeout' => $timeout,
             'version' => '1.9.0',
-            'connect_timeout' => $connectTimeout
+            'connect_timeout' => $connectTimeout,
+            'features' => [
+                'lucene' => false
+            ]
         ];
         if (!empty($version)) {
             $config['version'] = $version;

--- a/tests/Unit/OcSearchTest.php
+++ b/tests/Unit/OcSearchTest.php
@@ -42,12 +42,8 @@ class OcSearchTest extends TestCase
      */
     public function get_lucenes($params, $format): void
     {
-        if ($this->ocSearch->lucene) {
-            $response = $this->ocSearch->getLucene($params, $format);
-            $this->assertSame(200, $response['code'], 'Failure to search lucene');
-        } else {
-            $this->assertTrue(true);
-        }
+        $response = $this->ocSearch->getLucene($params, $format);
+        $this->assertContains($response['code'], [200, 410], 'Failure to create an event');
     }
 }
 ?>

--- a/tests/Unit/OcSearchTest.php
+++ b/tests/Unit/OcSearchTest.php
@@ -35,5 +35,19 @@ class OcSearchTest extends TestCase
         $response = $this->ocSearch->getSeries($params, $format);
         $this->assertSame(200, $response['code'], 'Failure to search series');
     }
+
+    /**
+     * @test
+     * @dataProvider \Tests\DataProvider\SearchDataProvider::getLuceneQueryCases()
+     */
+    public function get_lucenes($params, $format): void
+    {
+        if ($this->ocSearch->lucene) {
+            $response = $this->ocSearch->getLucene($params, $format);
+            $this->assertSame(200, $response['code'], 'Failure to search lucene');
+        } else {
+            $this->assertTrue(true);
+        }
+    }
 }
 ?>

--- a/tests/Unit/OcSearchTest.php
+++ b/tests/Unit/OcSearchTest.php
@@ -28,16 +28,6 @@ class OcSearchTest extends TestCase
 
     /**
      * @test
-     * @dataProvider \Tests\DataProvider\SearchDataProvider::getLuceneQueryCases()
-     */
-    public function get_lucenes($params, $format): void
-    {
-        $response = $this->ocSearch->getLucene($params, $format);
-        $this->assertSame(200, $response['code'], 'Failure to search lucene');
-    }
-
-    /**
-     * @test
      * @dataProvider \Tests\DataProvider\SearchDataProvider::getSeriesQueryCases()
      */
     public function get_series($params, $format): void

--- a/tests/UnitMock/OcSearchTestMock.php
+++ b/tests/UnitMock/OcSearchTestMock.php
@@ -40,12 +40,7 @@ class OcSearchTestMock extends TestCase
 {
         $params = ['series' => true];
         $response = $this->ocSearch->getLucene($params);
-
-        if ($this->ocSearch->lucene) {
-            $this->assertSame(200, $response['code'], 'Failure to search lucene');
-        } else {
-            $this->assertFalse($response);
-        }
+        $this->assertContains($response['code'], [200, 410], 'Failure to create an event');
     }
 
     /**

--- a/tests/UnitMock/OcSearchTestMock.php
+++ b/tests/UnitMock/OcSearchTestMock.php
@@ -37,10 +37,15 @@ class OcSearchTestMock extends TestCase
      * @test
      */
     public function get_lucenes(): void
-    {
+{
         $params = ['series' => true];
         $response = $this->ocSearch->getLucene($params);
-        $this->assertSame(200, $response['code'], 'Failure to search lucene');
+
+        if ($this->ocSearch->lucene) {
+            $this->assertSame(200, $response['code'], 'Failure to search lucene');
+        } else {
+            $this->assertFalse($response);
+        }
     }
 
     /**


### PR DESCRIPTION
- Remove lucene search, does not exists anymore
-  Update allowed sort params and their spelling
- Update tests

Some things need to be discussed:
- Is it necessary to have the api versioned or is graceful degration enough (to get it to work with oc 16 AND before)?

There also seems to be a bug in OC which needs to be addressed first (the sort order currently only works with `title`)

Fixes #21 