### PR TITLE
Add workflow config params to ingest endpoint call

### DIFF
--- a/src/OpencastApi/Rest/OcIngest.php
+++ b/src/OpencastApi/Rest/OcIngest.php
@@ -431,10 +431,11 @@ class OcIngest extends OcRest
      * @param string $mediaPackage The media package
      * @param string $workflowDefinitionId (optional) Workflow definition id
      * @param string $workflowInstanceId (optional) The workflow instance ID to associate this ingest with scheduled events.
+     * @param array $workflowConfiguration Workflow configuration
      *
      * @return array the response result ['code' => 200, 'body' => '{XML (text) media package}']
      */
-    public function ingest($mediaPackage, $workflowDefinitionId = '', $workflowInstanceId = '')
+    public function ingest($mediaPackage, $workflowDefinitionId = '', $workflowInstanceId = '', $workflowConfiguration = [])
     {
         $uri = self::URI . "/ingest";
         if (!empty($workflowDefinitionId) && empty($workflowInstanceId)) {
@@ -448,6 +449,13 @@ class OcIngest extends OcRest
         if (!empty($workflowDefinitionId) && !empty($workflowInstanceId)) {
             $formData['workflowDefinitionId'] = $workflowDefinitionId;
             $formData['workflowInstanceId'] = $workflowInstanceId;
+        }
+
+        if (!empty($workflowConfiguration)) {
+            // Adding workflow configuration params into the form data one by one.
+            foreach ($workflowConfiguration as $config => $value) {
+                $formData[$config] = $value;
+            }
         }
 
         $options = $this->restClient->getFormParams($formData);

--- a/tests/Unit/OcIngestTest.php
+++ b/tests/Unit/OcIngestTest.php
@@ -206,7 +206,11 @@ class OcIngestTest extends TestCase
     public function ingest(array $ingestData): void
     {
         $workflowDefinitionId = 'schedule-and-upload';
-        $responseIngest = $this->ocIngest->ingest($ingestData['mediaPackage'], $workflowDefinitionId);
+        // Add workflow configuration params.
+        $workflowConfiguration = [
+            'straightToPublishing' => false
+        ];
+        $responseIngest = $this->ocIngest->ingest($ingestData['mediaPackage'], $workflowDefinitionId, '', $workflowConfiguration);
         $this->assertSame(200, $responseIngest['code'], 'Failure to ingest');
         $mediaPackage = $responseIngest['body'];
         $this->assertNotEmpty($mediaPackage);


### PR DESCRIPTION
This PR fixes #24

#### Description
The ingest endpoint function now has the capability of accepting wf params in an array and pass them to the ingest call as in the form data one by one.