### PR TITLE
Fix runWithRoles without api version in config

### DIFF
--- a/src/OpencastApi/Rest/OcRestClient.php
+++ b/src/OpencastApi/Rest/OcRestClient.php
@@ -140,7 +140,9 @@ class OcRestClient extends Client
     {
         if (empty($this->version)) {
             try {
-                $defaultVersion = $this->performGet('/api/version/default');
+                // We have to use and aux object, in order to prevent overwriting arguments of current object.
+                $aux = clone $this;
+                $defaultVersion = $aux->performGet('/api/version/default');
                 if (!empty($defaultVersion['body']) && isset($defaultVersion['body']->default)) {
                     $this->setVersion(str_replace(['application/', 'v', '+json'], ['', '', ''], $defaultVersion['body']->default));
                 } else {


### PR DESCRIPTION
This PR fixes #23,

### Description
refer to the issue's desc.

### Reason
The checker for hasVersion forces to call the performGet which ends up having overwrite the arguments of the Client object before the main call!

### Solution
Cloning the object to get the version!