### PR TITLE
Allow passing of options to guzzle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,3 +50,6 @@
 
 # 1.8.0
 - Fix for unauthorized access when extracting the Opencast API Version.
+
+# 1.9.0
+- Allow passing additonal options to Guzzle #30

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ $config = [
       'timeout' => 0,                                 // The API timeout. In seconds (default 0 to wait indefinitely). (optional)
       'connect_timeout' => 0,                         // The API connection timeout. In seconds (default 0 to wait indefinitely) (optional)
       'version' => null,                              // The API Version. (Default null). (optional)
-      'handler' => null                               // The callable Handler or HandlerStack. (Default null). (optional)
-      'features' => null                              // A set of additional features [e.g. lucene search]. (Default null). (optional)
+      'handler' => null,                               // The callable Handler or HandlerStack. (Default null). (optional)
+      'features' => null,                              // A set of additional features [e.g. lucene search]. (Default null). (optional)
+      'guzzle' => null,                                // Additional Guzzle Request Options. These options can overwrite some default options (Default null). (optional)
 ];
 
 $engageConfig = [
@@ -36,8 +37,9 @@ $engageConfig = [
       'timeout' => 0,                                 // The API timeout. In seconds (default 0 to wait indefinitely). (optional)
       'connect_timeout' => 0,                         // The API connection timeout. In seconds (default 0 to wait indefinitely) (optional)
       'version' => null,                              // The API version. (Default null). (optional)
-      'handler' => null                               // The callable Handler or HandlerStack. (Default null). (optional)
-      'features' => null                              // A set of additional features [e.g. lucene search]. (Default null). (optional)
+      'handler' => null,                               // The callable Handler or HandlerStack. (Default null). (optional)
+      'features' => null,                              // A set of additional features [e.g. lucene search]. (Default null). (optional)
+      'guzzle' => null,                                // Additional Guzzle Request Options. These options can overwrite some default options (Default null). (optional)
 ];
 
 use OpencastApi\Opencast;
@@ -74,8 +76,9 @@ $config = [
       'timeout' => 0,                                 // The API timeout. In seconds (default 0 to wait indefinitely). (optional)
       'connect_timeout' => 0,                         // The API connection timeout. In seconds (default 0 to wait indefinitely) (optional)
       'version' => null,                              // The API version. (Default null). (optional)
-      'handler' => null                               // The callable Handler or HandlerStack. (Default null). (optional)
-      'features' => null                              // A set of additional features [e.g. lucene search]. (Default null). (optional)
+      'handler' => null,                               // The callable Handler or HandlerStack. (Default null). (optional)
+      'features' => null,                              // A set of additional features [e.g. lucene search]. (Default null). (optional)
+      'guzzle' => null,                                // Additional Guzzle Request Options. These options can overwrite some default options (Default null). (optional)
 ];
 
 
@@ -114,10 +117,12 @@ $config = [
       'timeout' => 0,                                 // The API timeout. In seconds (default 0 to wait indefinitely). (optional)
       'connect_timeout' => 0,                         // The API connection timeout. In seconds (default 0 to wait indefinitely) (optional)
       'version' => null,                              // The API version. (Default null). (optional)
-      'handler' => null                               // The callable Handler or HandlerStack. (Default null). (optional)
-      'features' => null                              // A set of additional features [e.g. lucene search]. (Default null). (optional)
+      'handler' => null,                               // The callable Handler or HandlerStack. (Default null). (optional)
+      'features' => null,                              // A set of additional features [e.g. lucene search]. (Default null). (optional)
+      'guzzle' => null,                                // Additional Guzzle Request Options. These options can overwrite some default options (Default null). (optional)
 ];
 ```
+**UPDATE (v1.9.0):** a new config parameter called "guzzle" is introduced, which is intended to pass additional guzzle request options to the call. These options will take precedence over the default configs like uri, auth and timeouts, but some other options like query, fome_params and json will be overwritten by the function if present.
 **UPDATE (v1.7.0):** the new items called `features` is added to the configuration array. As of now, it is meant to hanlde the toggle behavior to enable/disable Lucene search endpoint simply by adding `'features' => ['lucene' => true]`. Just keep in mind that this endpoint id off by default and won't work in Opencast 16 onwards. Therefore, developer must be very careful to use this feature and to toggle it!
 
 NOTE: the configuration for presentation (`engage` node) responsible for search has to follow the same definition as normal config. But in case any parameter is missing, the value will be taken from the main config param.

--- a/src/OpencastApi/Opencast.php
+++ b/src/OpencastApi/Opencast.php
@@ -78,10 +78,11 @@ class Opencast
             'username' => 'admin',                          // The API username. (required)
             'password' => 'opencast',                       // The API password. (required)
             'timeout' => 0,                                 // The API timeout. In seconds (default 0 to wait indefinitely). (optional)
-            'connect_timeout' => 0                          // The API connection timeout. In seconds (default 0 to wait indefinitely) (optional)
-            'version' => null                               // The API Version. (Default null). (optional)
-            'handler' => null                               // The callable Handler or HandlerStack. (Default null). (optional)
-            'features' => null                              // A set of additional features [e.g. lucene search]. (Default null). (optional)
+            'connect_timeout' => 0,                          // The API connection timeout. In seconds (default 0 to wait indefinitely) (optional)
+            'version' => null,                               // The API Version. (Default null). (optional)
+            'handler' => null,                               // The callable Handler or HandlerStack. (Default null). (optional)
+            'features' => null,                              // A set of additional features [e.g. lucene search]. (Default null). (optional)
+            'guzzle' => null,                                // Additional Guzzle Request Options. These options can overwrite some default options (Default null). (optional)
         ]
 
         $engageConfig = [
@@ -89,10 +90,11 @@ class Opencast
             'username' => 'admin',                          // The API username. (required)
             'password' => 'opencast',                       // The API password. (required)
             'timeout' => 0,                                 // The API timeout. In seconds (default 0 to wait indefinitely). (optional)
-            'connect_timeout' => 0                          // The API connection timeout. In seconds (default 0 to wait indefinitely) (optional)
-            'version' => null                               // The API Version. (Default null). (optional)
-            'handler' => null                               // The callable Handler or HandlerStack. (Default null). (optional)
-            'features' => null                              // A set of additional features [e.g. lucene search]. (Default null). (optional)
+            'connect_timeout' => 0,                          // The API connection timeout. In seconds (default 0 to wait indefinitely) (optional)
+            'version' => null,                               // The API Version. (Default null). (optional)
+            'handler' => null,                               // The callable Handler or HandlerStack. (Default null). (optional)
+            'features' => null,                              // A set of additional features [e.g. lucene search]. (Default null). (optional)
+            'guzzle' => null,                                // Additional Guzzle Request Options. These options can overwrite some default options (Default null). (optional)
         ]
     */
     /**
@@ -175,6 +177,9 @@ class Opencast
         }
         if (!isset($engageConfig['features']) && isset($config['features'])) {
             $engageConfig['features'] = $config['features'];
+        }
+        if (!isset($engageConfig['guzzle']) && isset($config['guzzle'])) {
+            $engageConfig['guzzle'] = $config['guzzle'];
         }
         $this->engageRestClient = new OcRestClient($engageConfig);
     }

--- a/src/OpencastApi/Rest/OcRestClient.php
+++ b/src/OpencastApi/Rest/OcRestClient.php
@@ -18,6 +18,8 @@ class OcRestClient extends Client
     private $noHeader = false;
     private $origin;
     private $features = [];
+    private $global_options = [];
+
     /*
         $config = [
             'url' => 'https://develop.opencast.org/',       // The API url of the opencast instance (required)
@@ -57,6 +59,8 @@ class OcRestClient extends Client
         if (isset($config['features'])) {
             $this->features = $config['features'];
         }
+
+        $this->global_options = $config['guzzle'] ?: [];
 
         parent::__construct($parentConstructorConfig);
     }
@@ -101,6 +105,7 @@ class OcRestClient extends Client
 
     private function addRequestOptions($uri, $options)
     {
+        $globalOptions = $this->global_options;
 
         // Perform a temp no header request.
         if ($this->noHeader) {
@@ -150,7 +155,7 @@ class OcRestClient extends Client
             }
         }
 
-        $requestOptions = array_merge($generalOptions, $options);
+        $requestOptions = array_merge($generalOptions, $globalOptions, $options);
         return $requestOptions;
     }
 

--- a/src/OpencastApi/Rest/OcRestClient.php
+++ b/src/OpencastApi/Rest/OcRestClient.php
@@ -18,7 +18,7 @@ class OcRestClient extends Client
     private $noHeader = false;
     private $origin;
     private $features = [];
-    private $global_options = [];
+    private $globalOptions = [];
 
     /*
         $config = [
@@ -29,7 +29,8 @@ class OcRestClient extends Client
             'connect_timeout' => 0,                         // The API connection timeout. In seconds (default 0 to wait indefinitely) (optional)
             'version' => null,                               // The API Version. (Default null). (optional)
             'handler' => null,                               // The callable Handler or HandlerStack. (Default null). (optional)
-            'features' => null                              // A set of additional features [e.g. lucene search]. (Default null). (optional)
+            'features' => null,                              // A set of additional features [e.g. lucene search]. (Default null). (optional)
+            'guzzle' => null,                                // Additional Guzzle Request Options. These options can overwrite some default options (Default null). (optional)
         ]
     */
     public function __construct($config)
@@ -60,7 +61,9 @@ class OcRestClient extends Client
             $this->features = $config['features'];
         }
 
-        $this->global_options = $config['guzzle'] ?: [];
+        if (isset($config['guzzle'])) {
+            $this->globalOptions = $config['guzzle'];
+        }
 
         parent::__construct($parentConstructorConfig);
     }
@@ -105,12 +108,12 @@ class OcRestClient extends Client
 
     private function addRequestOptions($uri, $options)
     {
-        $globalOptions = $this->global_options;
+        $globalOptions = $this->globalOptions;
 
         // Perform a temp no header request.
         if ($this->noHeader) {
             $this->noHeader = false;
-            return array_merge($options , ['headers' => null]);
+            return array_merge($globalOptions, $options, ['headers' => null]);
         }
 
         $generalOptions = [];

--- a/tests/Unit/OcRestClientWithGuzzleOptionTest.php
+++ b/tests/Unit/OcRestClientWithGuzzleOptionTest.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use OpencastApi\Opencast;
+
+class OcRestClientWithGuzzleOptionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $config = \Tests\DataProvider\SetupDataProvider::getConfig();
+        $config['guzzle'] = [
+            'debug' => true,
+            'query' => ['limit' => 1],
+            'auth' => [
+                $config['username'], $config['password']
+            ]
+        ];
+        $ocRestApi = new Opencast($config, [], false);
+        $this->ocBaseApi = $ocRestApi->baseApi;
+        $this->ocEventApi = $ocRestApi->eventsApi;
+
+        $config['guzzle']['auth'] = [
+            'faulty', 'faulty'
+        ];
+        $ocRestApiFaulty = new Opencast($config, [], false);
+        $this->ocBaseApiFaulty = $ocRestApiFaulty->baseApi;
+    }
+
+    /**
+     * @test
+     */
+    public function get(): void
+    {
+        $response = $this->ocBaseApi->get();
+        $this->assertSame(200, $response['code'], 'Failure to get base info');
+    }
+
+    /**
+     * @test
+     */
+    public function get_events_overwrite_guzzle_option(): void
+    {
+        $response = $this->ocEventApi->getAll(['limit' => 4]);
+        $this->assertSame(200, $response['code'], 'Failure to get events');
+        $this->assertSame(4, count($response['body']), 'Failure to get specifically 4 events.');
+    }
+
+    /**
+     * @test
+     */
+    public function get_faulty(): void
+    {
+        $response = $this->ocBaseApiFaulty->get();
+        $this->assertSame(401, $response['code'], 'Failure to overwrite default option!');
+    }
+
+    /**
+     * @test
+     */
+    public function get_no_auth(): void
+    {
+        $response = $this->ocBaseApi->noHeader()->get();
+        $this->assertSame(200, $response['code'], 'Failure to get base info');
+        $this->assertSame(true, is_object($response['body']), 'Failure to get base info correctly');
+    }
+}
+?>


### PR DESCRIPTION
This change allows adding options for Guzzle with the array key `'guzzle' => []` on instantiation of the API. 