### PR TITLE
Workflow API update and enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .phpunit.result.cache
 .DS_Store
 .gitignore
+.lmsupdatenotes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,4 +52,7 @@
 - Fix for unauthorized access when extracting the Opencast API Version.
 
 # 1.9.0
-- Allow passing additonal options to Guzzle #30
+- Allow passing additional options to Guzzle [#30]
+- WorkflowApi endpoint methods got updated
+  - `withconfigurationpaneljson` parameter has been added to `/api/workflow-definitions` endpoints. [#34]
+  - `@deprecated` removal of OcWorkflowsApi::geAll() method!

--- a/src/OpencastApi/Rest/OcWorkflowsApi.php
+++ b/src/OpencastApi/Rest/OcWorkflowsApi.php
@@ -15,54 +15,12 @@ class OcWorkflowsApi extends OcRest
     ## [Section 1]: General API endpoints.
 
     /**
-     * Returns a list of workflow instances.
-     * 
-     * @param array $params (optional) The list of query params to pass which can contain the followings:
-     * [
-     *      'withoperations' => '{Whether the workflow operations should be included in the response}',
-     *      'withconfiguration' => '{Whether the workflow configuration should be included in the response}',
-     *      'sort' => '{an assiciative array for sorting e.g. ['event_identifier' => 'DESC']}',
-     *      'limit' => '{the maximum number of results to return}',
-     *      'offset' => '{the index of the first result to return}',
-     *      'filter' => '{an assiciative array for filtering e.g. ['state' => '{Workflow instances that are in this state}']}',
-     * ]     
-     * 
-     * @return array the response result ['code' => 200, 'body' => '{A (potentially empty) list of workflow instances}']
-     * @deprecated since v1.3 because this endpoint is removed from Opencast Verison 12.x, we will no longer support it here.
-     */
-    public function getAll($params = [])
-    {
-        $uri = self::URI;
-
-        $query = [];
-        if (isset($params['filter']) && is_array($params['filter']) && !empty($params['filter'])) {
-            $query['filter'] = $this->convertArrayToFiltering($params['filter']);
-        }
-        if (isset($params['sort']) && is_array($params['sort']) && !empty($params['sort'])) {
-            $query['sort'] = $this->convertArrayToSorting($params['sort']);
-        }
-
-        $acceptableParams = [
-            'sort', 'limit', 'offset', 'filter', 'withoperations', 'withconfiguration'
-        ];
-
-        foreach ($params as $param_name => $param_value) {
-            if (in_array($param_name, $acceptableParams) && !array_key_exists($param_name, $query)) {
-                $query[$param_name] = $param_value;
-            }
-        }
-
-        $options = $this->restClient->getQueryParams($query);
-        return $this->restClient->performGet($uri, $options);
-    }
-    
-    /**
      * Returns a single workflow instance.
-     * 
-     * @param string $workflowInstanceId The workflow instance id 
+     *
+     * @param string $workflowInstanceId The workflow instance id
      * @param boolean $withoperations (optional) Whether the workflow operations should be included in the response (Default value=false)
      * @param boolean $withconfiguration (optional) Whether the workflow configuration should be included in the response (Default value=false)
-     * 
+     *
      * @return array the response result ['code' => 200, 'body' => '{ The workflow instance}']
      */
     public function get($workflowInstanceId, $withoperations = false, $withconfiguration = false)
@@ -76,20 +34,20 @@ class OcWorkflowsApi extends OcRest
         if (is_bool($withconfiguration)) {
             $query['withconfiguration'] = $withconfiguration;
         }
-        
+
         $options = $this->restClient->getQueryParams($query);
         return $this->restClient->performGet($uri, $options);
     }
 
     /**
      * Creates (runs) a workflow instance agianst an event.
-     * 
+     *
      * @param string $eventIdentifier The event identifier this workflow should run against
      * @param string $definitionIdentifier The identifier of the workflow definition to use
      * @param string|array $configuration (optional) The optional configuration for this workflow
      * @param boolean $withoperations (optional) Whether the workflow operations should be included in the response (Default value=false)
      * @param boolean $withconfiguration (optional) Whether the workflow configuration should be included in the response (Default value=false)
-     * 
+     *
      * @return array the response result ['code' => 201, 'body' => '{A new workflow is created and its identifier as Object is returned}', 'location' => 'The url']
      */
     public function run($eventIdentifier, $definitionIdentifier, $configuration = [], $withoperations = false, $withconfiguration = false)
@@ -120,13 +78,13 @@ class OcWorkflowsApi extends OcRest
 
     /**
      * Updates a workflow instance.
-     * 
-     * @param string $workflowInstanceId The workflow instance id 
+     *
+     * @param string $workflowInstanceId The workflow instance id
      * @param string $state (optional) The optional state transition for this workflow
      * @param string|array $configuration (optional) The optional configuration for this workflow
      * @param bool $withoperations (optional) Whether the workflow operations should be included in the response (Default value=false)
      * @param bool $withconfiguration (optional) Whether the workflow configuration should be included in the response (Default value=false)
-     * 
+     *
      * @return array the response result ['code' => 200, 'reason' => 'OK'] (updated)
      */
     public function update($workflowInstanceId, $state = '', $configuration = [], $withoperations = false, $withconfiguration = false)
@@ -157,9 +115,9 @@ class OcWorkflowsApi extends OcRest
 
     /**
      * Deletes a workflow instance.
-     * 
-     * @param string $workflowInstanceId The workflow instance id 
-     * 
+     *
+     * @param string $workflowInstanceId The workflow instance id
+     *
      * @return array the response result ['code' => 204, 'reason' => 'No Content'] (deleted)
      */
     public function delete($workflowInstanceId)
@@ -170,22 +128,23 @@ class OcWorkflowsApi extends OcRest
 
     ## End of [Section 1]: General API endpoints.
 
-    ## [Section 2]: Workflow definitions.
+    ## [Section 2]: Workflow definitions API endpoints.
 
     /**
      * Returns a list of workflow definitions.
-     * 
+     *
      * @param array $params (optional) The list of query params to pass which can contain the followings:
      * [
      *      'withoperations' => '{(boolean) Whether the workflow operations should be included in the response}',
      *      'withconfigurationpanel' => '{(boolean) Whether the workflow configuration panel should be included in the response}',
+     *      'withconfigurationpaneljson' => '{(boolean) Whether the workflow configuration panel in JSON should be included in the response [this is a must for Opencast 17]
      *      'sort' => '{an assiciative array for sorting e.g. ['title' => 'DESC']}',
      *      'limit' => '{the maximum number of results to return}',
      *      'offset' => '{the index of the first result to return}',
      *      'filter' => '{an assiciative array for filtering e.g. ['tag' => '{Workflow definitions where the tag is included}']}',
-     * ]     
-     * 
-     * @return array the response result ['code' => 200, 'body' => '{A (potentially empty) list of workflow definitions}']     
+     * ]
+     *
+     * @return array the response result ['code' => 200, 'body' => '{A (potentially empty) list of workflow definitions}']
      */
     public function getAllDefinitions($params = [])
     {
@@ -200,7 +159,7 @@ class OcWorkflowsApi extends OcRest
         }
 
         $acceptableParams = [
-            'sort', 'limit', 'offset', 'filter', 'withoperations', 'withconfigurationpanel'
+            'sort', 'limit', 'offset', 'filter', 'withoperations', 'withconfigurationpanel', 'withconfigurationpaneljson'
         ];
 
         foreach ($params as $param_name => $param_value) {
@@ -215,14 +174,15 @@ class OcWorkflowsApi extends OcRest
 
     /**
      * Returns a single workflow definition.
-     * 
+     *
      * @param string $workflowDefinitionId the identifier of the workflow definition.
      * @param boolean $withoperations (optional) Whether the workflow operations should be included in the response (Default value=false)
      * @param boolean $withconfigurationpanel (optional) Whether the workflow configuration should be included in the response (Default value=false)
-     * 
+     * @param boolean $withconfigurationpaneljson (optional) Whether the workflow configuration panel in JSON should be included in the response (Default value=false)
+     *
      * @return array the response result ['code' => 200, 'body' => '{ The workflow definition is returned as JSON object}']
      */
-    public function getDefinition($workflowDefinitionId, $withoperations = false, $withconfigurationpanel = false)
+    public function getDefinition($workflowDefinitionId, $withoperations = false, $withconfigurationpanel = false, $withconfigurationpaneljson = false)
     {
         $uri = self::URI_SECTION_2 . "/{$workflowDefinitionId}";
 
@@ -233,7 +193,10 @@ class OcWorkflowsApi extends OcRest
         if (is_bool($withconfigurationpanel)) {
             $query['withconfigurationpanel'] = $withconfigurationpanel;
         }
-        
+        if (is_bool($withconfigurationpaneljson)) {
+            $query['withconfigurationpaneljson'] = $withconfigurationpaneljson;
+        }
+
         $options = $this->restClient->getQueryParams($query);
         return $this->restClient->performGet($uri, $options);
     }

--- a/tests/DataProvider/WorkflowsApiDataProvider.php
+++ b/tests/DataProvider/WorkflowsApiDataProvider.php
@@ -1,18 +1,19 @@
-<?php 
+<?php
 namespace Tests\DataProvider;
 
 class WorkflowsApiDataProvider {
-    
-    public static function getAllCases(): array
+
+    public static function getAllDefinitionsCases(): array
     {
         return [
             [[]],
             [['withoperations' => true]],
-            [['withconfiguration' => true]],
-            [['sort' => ['workflow_definition_identifier' => 'DESC']]],
+            [['withconfigurationpanel' => true]],
+            [['withconfigurationpaneljson' => true]],
+            [['sort' => ['identifier' => 'DESC']]],
             [['limit' => 2]],
             [['offset' => 1]],
-            [['filter' => ['workflow_definition_identifier' => 'fast']]],
+            [['filter' => ['tag' => 'schedule']]],
         ];
     }
 }

--- a/tests/DataProvider/mock_responses/api_workflows.json
+++ b/tests/DataProvider/mock_responses/api_workflows.json
@@ -17,7 +17,7 @@
             }
         ]
     },
-    "/api/workflow-definitions/noop?withoperations=true&withconfigurationpanel=true": {
+    "/api/workflow-definitions/noop?withoperations=true&withconfigurationpanel=true&withconfigurationpaneljson=false": {
         "GET": [
             {
                 "body": "{\"identifier\":\"noop\",\"description\":\"\",\"title\":\"Do nothing (mostly for debugging and maintenance purposes)\",\"tags\":[]}",

--- a/tests/Unit/OcWorkflowsApiTest.php
+++ b/tests/Unit/OcWorkflowsApiTest.php
@@ -19,19 +19,6 @@ class OcWorkflowsApiTest extends TestCase
 
     /**
      * @test
-     * @dataProvider \Tests\DataProvider\WorkflowsApiDataProvider::getAllCases()
-     */
-    public function get_all_workflows($params): void
-    {
-        $this->markTestSkipped('Depricated Endpoint (removed from Opencast v12.x)');
-        $response = $this->ocWorkflowsApi->getAll($params);
-
-        $this->assertSame(200, $response['code'], 'Failure to get workflows list');
-    }
-
-
-    /**
-     * @test
      */
     public function get_definition_run_update_delete_workflow(): void
     {
@@ -97,6 +84,54 @@ class OcWorkflowsApiTest extends TestCase
         $response6 = $this->ocWorkflowsApi->delete($workflowId->identifier);
         $this->assertSame(204, $response6['code'], 'Failure to delete a workflow');
         sleep(1);
+    }
+
+    /**
+     * @test
+     * @dataProvider \Tests\DataProvider\WorkflowsApiDataProvider::getAllDefinitionsCases()
+     */
+    public function get_all_definitions($params): void
+    {
+        $response = $this->ocWorkflowsApi->getAllDefinitions($params);
+        $this->assertSame(200, $response['code'], 'Failure to get workflows list');
+    }
+
+    /**
+     * @test
+     * This test is meant to check the integrity of the response body, to make sure it contains the correct properties.
+     */
+    public function get_single_definition_with_parameters(): void
+    {
+        $response = $this->ocWorkflowsApi->getDefinition(
+            'fast',
+            true,
+            true,
+            true
+        );
+        $this->assertSame(200, $response['code'], 'Failure to get "fast" workflow');
+        $bodyArray = json_decode(json_encode($response['body']), true);
+        $this->assertNotEmpty($bodyArray, 'Response body array is empty');
+
+        // Check for operations
+        $this->assertArrayHasKey('operations', $bodyArray, 'No configuration_panel is defined');
+
+        // Check for config panel
+        $this->assertArrayHasKey('configuration_panel', $bodyArray, 'No configuration_panel is defined');
+
+        // Check for config panel json
+        $this->assertArrayHasKey('configuration_panel_json', $bodyArray, 'No configuration_panel_json is defined');
+
+        // Check for title
+        $this->assertArrayHasKey('title', $bodyArray, 'No configuration_panel_json is defined');
+
+        // Check for tags
+        $this->assertArrayHasKey('tags', $bodyArray, 'No configuration_panel_json is defined');
+
+        // Check for description
+        $this->assertArrayHasKey('description', $bodyArray, 'No configuration_panel_json is defined');
+
+        // Check for identifier
+        $this->assertArrayHasKey('identifier', $bodyArray, 'No configuration_panel_json is defined');
     }
 }
 ?>


### PR DESCRIPTION
This PR fixes #34,

### Description
The Workflow Definitions API endpoint has introduced a new parameter, `withconfigurationpaneljson`, which acts as a flag to retrieve the configuration panel in JSON format. This parameter was introduced in Opencast 16 and has become the only available format in Opencast 17.  


### What is in this PR
- Added support for the `withconfigurationpaneljson` parameter in methods related to the `api/workflow-definitions` endpoints.  
- Included PHPUnit tests to cover these additions.  
- Verified compatibility with Opencast 15, 16, and 17.  
