### PR TITLE
Add `includeInternalPublication` parameter to Events API methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,4 +61,4 @@
 - Repair and enhance Event API `addTrack`under `/api/events/{eventId}/track` [#36]
   - Tags are now added, therefore it can be replaced by ingest method.
   - overwriteExisting flag has been fixed and works as expected now!
-
+- Introduce `includeInternalPublication` in Events API `getAll`, `get` and `getPublications` methods [#37]

--- a/src/OpencastApi/Rest/OcEventsApi.php
+++ b/src/OpencastApi/Rest/OcEventsApi.php
@@ -24,6 +24,7 @@ class OcEventsApi extends OcRest
      *      'withmetadata' => (boolean) {Whether the metadata catalogs should be included in the response. },
      *      'withscheduling' => (boolean) {Whether the scheduling information should be included in the response. (version 1.1.0 and higher)},
      *      'withpublications' => (boolean) {Whether the publication ids and urls should be included in the response.},
+     *      'includeInternalPublication' => (boolean) {Whether internal publications should be included.},
      *      'onlyWithWriteAccess' => (boolean) {Whether only to get the events to which we have write access.},
      *      'sort' => (array) {an assiciative array for sorting e.g. ['title' => 'DESC']},
      *      'limit' => (int) {the maximum number of results to return},
@@ -47,7 +48,7 @@ class OcEventsApi extends OcRest
 
         $acceptableParams = [
             'sign', 'withacl', 'withmetadata', 'withpublications',
-            'onlyWithWriteAccess', 'sort', 'limit', 'offset', 'filter'
+            'onlyWithWriteAccess', 'sort', 'limit', 'offset', 'filter', 'includeInternalPublication'
         ];
 
         if ($this->restClient->hasVersion('1.1.0')) {
@@ -106,6 +107,7 @@ class OcEventsApi extends OcRest
      *      'withmetadata' => (boolean) {Whether the metadata catalogs should be included in the response. },
      *      'withscheduling' => (boolean) {Whether the scheduling information should be included in the response. (version 1.1.0 and higher)},
      *      'withpublications' => (boolean) {Whether the publication ids and urls should be included in the response.}
+     *      'includeInternalPublication' => (boolean) {Whether internal publications should be included.}
      * ]
      *
      * @return array the response result ['code' => 200, 'body' => 'The event (Object)']
@@ -116,7 +118,7 @@ class OcEventsApi extends OcRest
         $query = [];
 
         $acceptableParams = [
-            'sign', 'withacl', 'withmetadata', 'withpublications'
+            'sign', 'withacl', 'withmetadata', 'withpublications', 'includeInternalPublication'
         ];
 
         if ($this->restClient->hasVersion('1.1.0')) {
@@ -438,13 +440,20 @@ class OcEventsApi extends OcRest
      *
      * @param string $eventId the event identifier
      * @param boolean $sign (optional) Whether publication urls (version 1.7.0 or higher) and distribution urls should be pre-signed.
+     * @param boolean $includeInternalPublication (optional) Whether internal publications should be included.
      *
      * @return array the response result ['code' => 200, 'body' => '{The list of publications}']
      */
-    public function getPublications($eventId, $sign = false)
+    public function getPublications($eventId, $sign = false, $includeInternalPublication = false)
     {
         $uri = self::URI . "/{$eventId}/publications";
-        $query['sign'] = $sign;
+        if ($sign) {
+            $query['sign'] = 'true';
+        }
+        if ($includeInternalPublication) {
+            $query['includeInternalPublication'] = 'true';
+        }
+
         $options = $this->restClient->getQueryParams($query);
         return $this->restClient->performGet($uri, $options);
     }

--- a/tests/DataProvider/EventsDataProvider.php
+++ b/tests/DataProvider/EventsDataProvider.php
@@ -13,6 +13,7 @@ class EventsDataProvider {
             [['withmetadata' => true]],
             [['withpublications' => true]],
             [['withscheduling' => true]],
+            [['includeInternalPublication' => true]],
             [['sort' => ['title' => 'DESC']]],
             [['limit' => 2]],
             [['offset' => 1, 'limit' => 2]],

--- a/tests/Unit/OcEventsApiTest.php
+++ b/tests/Unit/OcEventsApiTest.php
@@ -54,7 +54,7 @@ class OcEventsApiTest extends TestCase
      */
     public function get_single_event(string $identifier): string
     {
-        $responseAll = $this->ocEventsApi->getAll(['withacl' => true]);
+        $responseAll = $this->ocEventsApi->getAll(['withacl' => true, 'includeInternalPublication' => true]);
         $this->assertSame(200, $responseAll['code'], 'Failure to get event list');
         $events = $responseAll['body'];
         if (!empty($events)) {
@@ -289,7 +289,7 @@ class OcEventsApiTest extends TestCase
      */
     public function get_publications(string $identifier): string
     {
-        $response1 = $this->ocEventsApi->getPublications($identifier, true);
+        $response1 = $this->ocEventsApi->getPublications($identifier, true, true);
         $this->assertSame(200, $response1['code'], 'Failure to get publications of an event');
 
         $publications = $response1['body'];


### PR DESCRIPTION
This PR fixes #37,

### Description
There was a minor but practical addition to the event api (get, getAll and getPublications) methods, which makes it possible to select whether to include internal publication when calling these APIs.

### What has been added
- `OcEventsApi::getAll` now accepts the `includeInternalPublication` param in the list of params.
- `OcEventsApi::get` now accepts the `includeInternalPublication` param in the list of params.
- `OcEventsApi::getPublications` now accepts the `includeInternalPublication` param as its third method argument!